### PR TITLE
Fixes boolean in docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Set sitewide options in Wintersmith's `config.json`. If `noindex` is set globall
 {
     "locals": {
         "sitemap": "sitemap.xml",
-        "noindex": "false"
+        "noindex": false
     }
 
 }


### PR DESCRIPTION
In using `noindex: "false"` per the docs, I found that my robots.txt looked like this:

```
User-agent: *
Disallow: /
```

I changed my config to `noindex: false` and I got what I wanted:

```
User-agent: *
Sitemap: https://gavd.co.uk/sitemap.xml
```